### PR TITLE
Redirect to project pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,10 @@
-<h1>Placeholder</h1>
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>SSH.NET</title>
+        <meta http-equiv="Refresh" content="0; URL=https://sshnet.github.io/SSH.NET/" />
+    </head>
+    <body>
+        Redirecting to <a href="https://sshnet.github.io/SSH.NET/">https://sshnet.github.io/SSH.NET/</a>
+    </body>
+</html>


### PR DESCRIPTION
With any luck this will redirect the github "organisation" pages ([sshnet.github.io](https://sshnet.github.io)) to the project pages ([sshnet.github.io/SSH.NET/](https://sshnet.github.io/SSH.NET/))

@drieseng @WojciechNagorski